### PR TITLE
Redefined function taxa2samples()

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
       - name: Install dependencies
         run: |
-          install.packages(c("remotes", "rcmdcheck"))
+          install.packages(c("remotes", "rcmdcheck", "sf"))
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}
       - name: Check

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,30 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: covr
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,11 +8,12 @@ vegtable 0.1.8
 
 ## Improvements
 
-* Slot **relations** may deal with any element that canbe coerced to
+* Slot **relations** may deal with any element that can be coerced to
   `data.frame`.
 * All elements in slot **syntax** have to be of class `taxlist`
 * Parameter `in_header` defined in several functions is set as
-  `in_header = TRUE`. 
+  `in_header = TRUE`.
+* Former method for 'aggregate()' is now defined in function 'veg_aggregate()'.
 
 ## Bug Fixes
 

--- a/man/Extract.Rd
+++ b/man/Extract.Rd
@@ -9,9 +9,9 @@
 \alias{$<-,vegtable-method}
 \alias{$,coverconvert-method}
 \alias{$<-,coverconvert,list-method}
-\alias{[,vegtable,ANY,ANY,ANY-method}
-\alias{[}
 \alias{[,vegtable-method}
+\alias{[}
+\alias{[,vegtable,ANY,ANY,ANY-method}
 \alias{[<-,vegtable-method}
 \alias{[<-}
 \title{Select or replace elements in objects}
@@ -24,7 +24,7 @@
 
 \S4method{$}{coverconvert,list}(x, name) <- value
 
-\S4method{[}{vegtable,ANY,ANY,ANY}(x, i, j, ..., drop = FALSE)
+\S4method{[}{vegtable}(x, i, j, ..., drop = FALSE)
 
 \S4method{[}{vegtable}(x, i, j) <- value
 }


### PR DESCRIPTION
This new definition will preserve the original content in slot **samples**. By this way functions such as `used_synonyms()` and `used_concepts()` will still deliver the correct information.
This pull request closes #21 